### PR TITLE
Patch for "'numpy/math.pxd' not found" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,11 +117,18 @@ RUN python3 -m pip install --user --upgrade --break-system-packages pip
 RUN pip3 install --user --no-warn-script-location --ignore-installed --break-system-packages \
         capstone jinja2 meson poetry pythonnet thefuck tinyscript tldr vt-py \
  && pip3 install --user --no-warn-script-location --ignore-installed --break-system-packages \
-        angr capa lightgbm pandas pydl8.5 scikit-learn scikit-learn-extra weka \
+        angr capa lightgbm pandas pydl8.5 scikit-learn weka \
  && rm -f /home/user/.local/lib/python3.11/site-packages/unicorn/lib \
  && pip3 uninstall -y --break-system-packages unicorn \
  && pip3 install --user --no-warn-script-location --ignore-installed --break-system-packages unicorn \
  && pip3 install --user --break-system-packages git+https://github.com/freakboy3742/pyspamsum
+# install scikit-learn-extra
+# Clone and patch scikit-learn-extra
+RUN git clone https://github.com/scikit-learn-contrib/scikit-learn-extra.git /tmp/scikit-learn-extra \
+    && sed -i 's/from numpy.math cimport INFINITY/cdef double INFINITY = float("inf")/' \
+    /tmp/scikit-learn-extra/sklearn_extra/robust/_robust_weighted_estimator_helper.pyx \
+    && cd /tmp/scikit-learn-extra \
+    && pip3 install --user --no-warn-script-location --ignore-installed --break-system-packages .
 # install ILSpyCmd
 RUN dotnet tool install --global ilspycmd
 # install Rust (user-level


### PR DESCRIPTION
Building the main branch (9069f688f5746b919ce732229242d428486beab8) fails with
74.28       from libc.math cimport exp, log, sqrt, pow, fabs
74.28       cimport numpy as np
74.28       from numpy.math cimport INFINITY
74.28       ^
74.28  ------------------------------------------------
74.28
74.28 sklearn_extra/robust/_robust_weighted_estimator_helper.pyx:18:0: ' 14 numpy/math.pxd' not found
74.28
74.28       Error compiling Cython file:
...

This is a patch to get around the error.